### PR TITLE
use more portable psutil library instead of syscall

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Chaos is a tool to create chaos in your server.
 
 ## Overview
 
-Chaos is an agent tool to create chaos in your local machine. It's manageg by another project chaos-manager.
+Chaos is an agent tool to create chaos in your local machine. It's managed by another project chaos-manager.
 
 ## Installation
 
-Make sure you have a working Go environment.  Go version 1.2+ is supported.  [See
+Make sure you have a working Go environment.  Go version 1.7+ is supported.  [See
 the install instructions for Go](http://golang.org/doc/install.html).
 
 To install cli, simply run:

--- a/ram.go
+++ b/ram.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
+
+	"github.com/shirou/gopsutil/mem"
 )
 
 var overall [][]int
@@ -16,15 +17,13 @@ func ram(usageString string) {
 	if strings.HasSuffix(usageString, "%") {
 		usageString = strings.TrimSuffix(usageString, "%")
 		percent, _ := strconv.ParseUint(usageString, 10, 64)
-		si := &syscall.Sysinfo_t{}
-
-		err := syscall.Sysinfo(si)
+		vm, err := mem.VirtualMemory()
 		if err != nil {
-			panic("Commander, we have a problem. syscall.Sysinfo:" + err.Error())
+			panic("Commander, we have a problem. mem.VirtualMemory:" + err.Error())
 		}
-		//fmt.Println(si.Freeram)
-		//fmt.Println(si.Bufferram)
-		size = (si.Freeram + si.Bufferram) * percent / 100
+		// fmt.Println(vm)
+		size = vm.Available
+		size = size * percent / 100
 	} else {
 		size, _ = strconv.ParseUint(usageString, 10, 64)
 		size *= 1000000 //change from MB to B


### PR DESCRIPTION
I was trying to build on the Mac OS and got errors because of missing sysinfo type. 
the `psutils` library seems to be working, but maybe requires an additional testing - I've used Mac OS because I have linux only on remote machines